### PR TITLE
Private functions & mixins

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 1.0.0 (2018-12-11)
+    * Turn 'allow-leading-underscore' back on for mixins and functions
+	* Enables common format for private functions/mixins
+	* Breaking change. First major version
+
 ## 0.1.2 (2018-10-17)
     * Fix bug in iinstructions for use
 

--- a/config/.sass-lint.yml
+++ b/config/.sass-lint.yml
@@ -38,12 +38,10 @@ rules:
     function-name-format:
         - 2
         -
-            allow-leading-underscore: false
             convention: hyphenatedlowercase
     mixin-name-format:
         - 2
         -
-            allow-leading-underscore: false
             convention: hyphenatedlowercase
 
     # Rules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/sasslint-config",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Sass Lint shareable config used at Springer Nature",
   "license": "",
   "repository": "springernature/sasslint-config-springernature",


### PR DESCRIPTION
Allows `functions` and `mixins` to use a leading underscore in the name. This is a common convention for defining a 'private' function or mixin.

Prefix private data (mixins, variables, and functions that are only used internally) using an underscore, that’s also common practice in other languages. This is useful because an IDE will not suggest an auto-completion for private stuff and prevents naming conflicts with other libraries.

```
$_variable //private
$variable //public
@function _stuff() {..} //private
@function stuff() {..} //public
```