### PR TITLE
…

### DIFF
--- a/config/.sass-lint.yml
+++ b/config/.sass-lint.yml
@@ -66,6 +66,8 @@ rules:
     extends-before-declarations: 2
     mixins-before-declarations:
         - 2
+        -
+          exclude: ['media-query']
 
     # Units
     no-invalid-hex: 2


### PR DESCRIPTION
add an exclusion for `mixins-before-declarations` rule, that allows the `media-query` mixin from `context` package to be used, see example here:

https://github.com/sasstools/sass-lint/blob/master/docs/rules/mixins-before-declarations.md