### PR TITLE
Allow leading underscore for functions and mixins

### DIFF
--- a/config/.sass-lint.yml
+++ b/config/.sass-lint.yml
@@ -44,6 +44,7 @@ rules:
         - 2
         -
             convention: hyphenatedlowercase
+            allow-leading-underscore: true
 
     # Rules
     no-empty-rulesets: 2

--- a/config/.sass-lint.yml
+++ b/config/.sass-lint.yml
@@ -39,6 +39,7 @@ rules:
         - 2
         -
             convention: hyphenatedlowercase
+            allow-leading-underscore: true
     mixin-name-format:
         - 2
         -


### PR DESCRIPTION
This loosens the rules slightly to allow leading underscores for both [function](https://github.com/michaelherold/codeclimate-sass-lint/blob/master/config/contents/function-name-format.md) and [mixin](https://github.com/michaelherold/codeclimate-sass-lint/blob/master/config/contents/mixin-name-format.md) names, as this is a convention that is common (and we use) for private functions/variables.

Examples:

```
@function _leading-underscore($x) {
  @return $x;
}

@mixin _leading-underscore() {
  content: '';
}
```